### PR TITLE
Implement is_taken and add a corner stone test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ From repository root:
 ```
 git clone https://github.com/lumapps/test-goban.git
 cd test-goban/python
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 PYTHONPATH=. pytest test_goban.py
 ```

--- a/python/goban.py
+++ b/python/goban.py
@@ -1,4 +1,5 @@
 import enum
+from collections.abc import Iterator
 
 
 class Status(enum.Enum):
@@ -10,6 +11,10 @@ class Status(enum.Enum):
     BLACK = 2
     EMPTY = 3
     OUT = 4
+
+
+# orthogonal neighbor offsets up down left right diagonals do not count
+_ORTHOGONAL_OFFSETS = ((0, -1), (0, 1), (-1, 0), (1, 0))
 
 
 class Goban:
@@ -44,4 +49,78 @@ class Goban:
         raise ValueError(f"Unknown goban value {self.goban[y][x]}")
 
     def is_taken(self, x: int, y: int) -> bool:
-        raise NotImplementedError
+        """
+        check whether the stone at a given position is taken
+
+        a stone is taken when its connected same color shape has no liberty
+        runs in linear time over the board each stone is visited once
+
+        args
+            x the x coordinate
+            y the y coordinate
+
+        returns
+            true if the stone is taken false otherwise
+        """
+        # if there is no stone here there is nothing to take so return false
+        if self.get_status(x, y) not in (Status.BLACK, Status.WHITE):
+            return False
+
+        # the stone is taken when its group has no free space next to it
+        return not self._has_liberty(self._shape_at(x, y))
+
+    def _neighbors(self, x: int, y: int) -> Iterator[tuple[int, int]]:
+        """yield the four ortogonal neighbors of x y diagonals do not count"""
+        # give back the cells above below left and right of x y
+        for dx, dy in _ORTHOGONAL_OFFSETS:
+            yield x + dx, y + dy
+
+    def _shape_at(self, x: int, y: int) -> set[tuple[int, int]]:
+        """collect every stone connected to x y that shares its color
+
+        iterative flood fill to avoid recursion limits on large bords
+        """
+        # the color of the group we are looking for
+        color = self.get_status(x, y)
+        # stones we already added to the group we also use this to not visit twice
+        shape: set[tuple[int, int]] = set()
+        # stones we still need to check
+        to_visit = [(x, y)]
+
+        while to_visit:
+            pos = to_visit.pop()
+            # skip if we have seen this stone already
+            if pos in shape:
+                continue
+            shape.add(pos)
+            # add neighbours of the same color that we have not seen yet
+            to_visit.extend(
+                n
+                for n in self._neighbors(*pos)
+                if n not in shape and self.get_status(*n) == color
+            )
+
+        return shape
+
+    def _has_liberty(self, stones: set[tuple[int, int]]) -> bool:
+        """true if any stone of the shape touches an empty point
+
+        board edges out are not libertis so they are simply ignored here
+        """
+        # true as soon as we find one empty cell next to any stone of the grup
+        return any(
+            self.get_status(nx, ny) == Status.EMPTY
+            for x, y in stones
+            for nx, ny in self._neighbors(x, y)
+        )
+
+if __name__ == "__main__":
+    demo = Goban([
+        ".#.",
+        "#o#",
+        ".#.",
+    ])
+    print("board")
+    for row in demo.goban:
+        print(row)
+    print("white stone at 1 1 taken", demo.is_taken(1, 1))

--- a/python/test_goban.py
+++ b/python/test_goban.py
@@ -59,3 +59,13 @@ def test_square_shape_is_taken() -> None:
     assert goban.is_taken(0, 2) is True
     assert goban.is_taken(1, 1) is True
     assert goban.is_taken(1, 2) is True
+
+
+def test_corner_stone_is_taken_using_board_edges() -> None:
+    # the black corner stone is walled in by white and the board edges out
+    goban = Goban([
+        '#o',
+        'o.',
+    ])
+
+    assert goban.is_taken(0, 0) is True


### PR DESCRIPTION
Implements `Goban.is_taken(x, y)` using a flood fill over the connected same-color shape: taken when no stone touches an EMPTY point(board edges are not liberties)
Adds one test for a stone captured by the board edges